### PR TITLE
Suggestion for how to use native bootstrap collapse functionality

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -17,61 +17,65 @@
     <div class="container text-center">
       <div class="row row-cols-2 row-cols-lg-5 g-2 g-lg-3">
         <div class="col">
-          <div class="p-3" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent1')">Weather</div>
-           <div class="collapse-content" id="collapseContent1" style="display: none">
-           <p>This is the collapsible content that will be shown or hidden.</p>
-           </div>
+          <div class="p-3 d-grid gap-2">
+            <button class="btn btn-primary btn-lg" type="button" data-bs-toggle="collapse" data-bs-target="#collapseContent1" aria-expanded="false" aria-controls="collapseContent1">
+              Weather
+            </button>
+            <div class="collapse collapse-content" id="collapseContent1">
+              <p>This is the collapsible content that will be shown or hidden.</p>
+            </div>
+          </div>
         </div>
         <div class="col">
-          <div class="p-3" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent2')">Row column</div>
+          <div class="p-3 collapse-button" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent2')">Row column</div>
           <div class="collapse-content" id="collapseContent2" style="display: none">
             <p>This is the collapsible content that will be shown or hidden.</p>
             </div>
         </div>
         <div class="col">
-          <div class="p-3" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent3')">Row column</div>
+          <div class="p-3 collapse-button" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent3')">Row column</div>
           <div class="collapse-content" id="collapseContent3" style="display: none">
             <p>This is the collapsible content that will be shown or hidden.</p>
             </div>
         </div>
         <div class="col">
-          <div class="p-3" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent')">Row column</div>
+          <div class="p-3 collapse-button" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent')">Row column</div>
           <div class="collapse-content" id="collapseContent" style="display: none">
             <p>This is the collapsible content that will be shown or hidden.</p>
             </div>
         </div>
         <div class="col">
-          <div class="p-3" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent4')">Row column</div>
+          <div class="p-3 collapse-button" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent4')">Row column</div>
           <div class="collapse-content" id="collapseContent4" style="display: none">
             <p>This is the collapsible content that will be shown or hidden.</p>
             </div>
         </div>
         <div class="col">
-          <div class="p-3" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent5')">Row column</div>
+          <div class="p-3 collapse-button" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent5')">Row column</div>
           <div class="collapse-content" id="collapseContent5" style="display: none">
             <p>This is the collapsible content that will be shown or hidden.</p>
             </div>
         </div>
         <div class="col">
-          <div class="p-3" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent6')">Row column</div>
+          <div class="p-3 collapse-button" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent6')">Row column</div>
           <div class="collapse-content" id="collapseContent6" style="display: none">
             <p>This is the collapsible content that will be shown or hidden.</p>
             </div>
         </div>
         <div class="col">
-          <div class="p-3" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent7')">Row column</div>
+          <div class="p-3 collapse-button" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent7')">Row column</div>
           <div class="collapse-content" id="collapseContent7" style="display: none">
             <p>This is the collapsible content that will be shown or hidden.</p>
             </div>
         </div>
         <div class="col">
-          <div class="p-3" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent8')">Row column</div>
+          <div class="p-3 collapse-button" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent8')">Row column</div>
           <div class="collapse-content" id="collapseContent8" style="display: none">
             <p>This is the collapsible content that will be shown or hidden.</p>
             </div>
         </div>
         <div class="col">
-          <div class="p-3" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent9')">Row column</div>
+          <div class="p-3 collapse-button" type="button" class="collapse-btn" onclick="toggleCollapse('collapseContent9')">Row column</div>
           <div class="collapse-content" id="collapseContent9" style="display: none">
             <p>This is the collapsible content that will be shown or hidden.</p>
             </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -26,7 +26,7 @@ header {
     font-size: 1.5rem;
 }
 
-.p-3 {
+.collapse-button {
     background-color: #00beef;
     padding: 10px;
     justify-content: space-around;
@@ -36,6 +36,6 @@ header {
     box-shadow: 5px 5px rgb(214, 182, 182);
 }
 
-<link>collapse-content</link> {
-    display: none; /* Hide the content by default */
-  }
+.collapse-content{
+  color: rgb(119, 119, 119);
+}


### PR DESCRIPTION
I love your show/hide function, and you've done an awesome job figuring it out and wiring it all up. It's super important in coding to have a good grasp of what's happening in the code you write, and writing your own functions to do this sort of stuff is a great way to get that understanding.

There's nothing wrong with the way you've done it, and it is fine to keep it that way. We don't have to merge this change, so it's completely up to you how you want to do it.

That said, I thought I'd mock up a quick example of what this might look like if you use bootstrap's collapse functionality instead of rolling your own.
The main benefit of using the bootstrap functionality is that they provide some pretty animations when opening and closing the collapse.
The main downside to using bootstrap for this is that it's arguably a little bit more code to add, and a little trickier to understand.

I've also included a few general coding suggestions/improvements, and will comment on those specifically in the PR.


I've temporarily made this version live on https://dnd.manncraft.nz/ if you'd like to test it out. I can revert to the original version at any time, just let me know.